### PR TITLE
Change package of FilterRegistrationBean

### DIFF
--- a/HOL/java/06-appinsights/end/src/main/java/devCamp/WebApp/configurations/AppInsightsConfig.java
+++ b/HOL/java/06-appinsights/end/src/main/java/devCamp/WebApp/configurations/AppInsightsConfig.java
@@ -2,7 +2,7 @@ package devCamp.WebApp.configurations;
 
 import javax.servlet.Filter;
 
-import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
**Summary**

The packaged referenced in this commit is depreciated in later versions of spring-boot. The correct Bean package in versions older than 1.4.x is org.springframework.boot.web.servlet.FilterRegistrationBean

See the depreciation notes here
https://github.com/spring-projects/spring-boot/blob/v1.4.1.RELEASE/spring-boot/src/main/java/org/springframework/boot/context/embedded/FilterRegistrationBean.java#L41-L42

When using this example as a base for newer spring-boot frameworks it will generate a ClassNotFound exception in the build.